### PR TITLE
chore(oss): add dependabot config, CI badge, and package metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # pnpm workspace dependencies (root manifest covers the monorepo)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Keep GitHub Actions in .github/workflows up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 >
 > **English**: README.md | **中文**: [README.zh-CN.md](README.zh-CN.md)
 
+[![CI](https://github.com/wemux-ai/wemux/actions/workflows/ci.yml/badge.svg)](https://github.com/wemux-ai/wemux/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
 [![Self-hosted](https://img.shields.io/badge/Self--hosted-✔-brightgreen.svg)](docs/SELF-HOSTING.md)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -2,12 +2,16 @@
   "name": "wemux",
   "version": "0.3.130",
   "description": "wemux — an AI delivery platform where workers execute code tasks on real device nodes: self-hostable control plane, web console, and worker daemon (monorepo).",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/wemux-ai/wemux.git"
   },
+  "bugs": "https://github.com/wemux-ai/wemux/issues",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "packageManager": "pnpm@10.24.0",
   "type": "module",
   "scripts": {

--- a/scripts/package-worker-npm.mjs
+++ b/scripts/package-worker-npm.mjs
@@ -49,6 +49,7 @@ const workerPackageJson = {
   version: finalVersion,
   private: false,
   type: 'module',
+  license: 'Apache-2.0',
   packageManager: rootPackageJson.packageManager,
   bin: {
     vbx: './bin/vbx.mjs',


### PR DESCRIPTION
## Summary

Open-source hygiene pass following a community-health review:

- Add `.github/dependabot.yml` — weekly updates for pnpm dependencies and GitHub Actions
- Add CI status badge to README
- `package.json`: use `Apache-2.0` SPDX license id, declare `engines` (node >=20, matching README), add `bugs` URL
- `scripts/package-worker-npm.mjs`: declare `Apache-2.0` license in the generated worker npm package (published to npm without a license field)

## Related issue

None (hygiene review findings).

## Changes

- [x] Docs / chore
- [x] Dependency change (tooling automation only, no runtime deps touched)

## Testing

- [x] `package.json` parses; boundary check passes (`public-boundary.mjs --staged`)
- [x] dependabot.yml YAML valid
- [ ] CI on this PR

## AI-generated code disclosure

- [x] This PR contains AI-generated or AI-assisted code
- [x] I am the human sponsor of this PR: I have reviewed every line, I can defend it in review, and I sign the DCO for it