### PR TITLE
ci(desktop): make release pipeline runnable without private signing secrets

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Build static renderer
         run: pnpm build:native:web-static
 
+      - name: Build meeting runtime
+        run: pnpm build:meeting-runtime
+
       - name: Build Electron artifacts
         working-directory: apps/desktop
         env:

--- a/apps/desktop/electron-builder.config.cjs
+++ b/apps/desktop/electron-builder.config.cjs
@@ -9,6 +9,9 @@ const runtimeBinary = process.platform === 'win32'
 const shouldNotarize = Boolean(
   process.env.APPLE_ID && process.env.APPLE_APP_SPECIFIC_PASSWORD && process.env.APPLE_TEAM_ID,
 )
+// Community builds run unsigned when no certificate secret is provided.
+// Signing is enabled per-platform by CSC_* secrets in native-release.yml.
+const shouldSignMac = Boolean(process.env.CSC_LINK || process.env.MACOS_CERTIFICATE)
 
 module.exports = {
   appId: 'com.wemux.app',
@@ -58,6 +61,7 @@ module.exports = {
   mac: {
     category: 'public.app-category.productivity',
     icon: 'assets/icons/icon.icns',
+    identity: shouldSignMac ? undefined : null,
     minimumSystemVersion: '10.15',
     extendInfo: {
       NSMicrophoneUsageDescription: 'Wemux uses the microphone for local meeting transcription.',


### PR DESCRIPTION
## Summary

Prepares the desktop release pipeline for its first public run (no `v*` tag has ever been pushed on this repo):

- `native-release.yml`: build the meeting-runtime native binary before `electron-builder` — the builder bundles it via `extraResources`, but a fresh CI checkout does not have it, so the job would fail with ENOENT
- `electron-builder.config.cjs`: skip macOS code signing (`identity: null`) when no `CSC_LINK`/`MACOS_CERTIFICATE` secret is configured, instead of failing the job; signing turns on automatically once certificate secrets are added
- Notarization remains conditional on `APPLE_*` secrets (unchanged)
- Empty `VITE_*` env is safe: desktop falls back to `DEFAULT_SERVER_URL` (wemux.ai) at runtime

## Changes

- [x] CI / build pipeline change

## Testing

- [x] `electron-builder.config.cjs` parses (`mac.identity === null` without secrets)
- [x] workflow YAML valid
- [ ] real validation happens on the next `v*` tag run

## AI-generated code disclosure

- [x] This PR contains AI-generated or AI-assisted code
- [x] I am the human sponsor of this PR: I have reviewed every line, I can defend it in review, and I sign the DCO for it