### PR TITLE
fix(build): resolve repo root via fileURLToPath in meeting-runtime build

### DIFF
--- a/scripts/build-meeting-runtime.mjs
+++ b/scripts/build-meeting-runtime.mjs
@@ -1,9 +1,10 @@
 import { existsSync, mkdirSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import process from 'node:process'
 
-const repoRoot = path.resolve(new URL('..', import.meta.url).pathname)
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const sourceDir = path.join(repoRoot, 'apps/meeting-runtime/native')
 const buildDir = path.join(sourceDir, 'build')
 mkdirSync(buildDir, { recursive: true })


### PR DESCRIPTION
## Summary

Follow-up to #23 — the meeting-runtime build step added for the first `v0.3.130` tag run crashed on `windows-latest`:

```
Error: ENOENT: mkdir 'D:\D:\a\wemux\wemux\apps\meeting-runtime\native\build'
```

`new URL('..', import.meta.url).pathname` keeps the leading slash on Windows (`/D:/...`), and `path.resolve` then glues it into a double drive letter. Use `fileURLToPath` instead. macOS/Linux are unaffected; this is the only occurrence of the pattern in `scripts/`.

## Changes

- [x] Bug fix

## Testing

- [x] `node --check` passes; syntax validated
- [ ] next `v0.3.130` tag run on windows-latest

## AI-generated code disclosure

- [x] This PR contains AI-generated or AI-assisted code
- [x] I am the human sponsor of this PR: I have reviewed every line, I can defend it in review, and I sign the DCO for it