### PR TITLE
ci(desktop): cap meeting-runtime build parallelism at -j2

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -60,6 +60,10 @@ jobs:
         run: pnpm build:native:web-static
 
       - name: Build meeting runtime
+        # 公开 runner 内存有限（ubuntu/macos 7GB），llama 栈全核并行会 OOM（cc1plus 被 kill），
+        # 限到 -j2 换取三平台稳定出包。
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: "2"
         run: pnpm build:meeting-runtime
 
       - name: Build Electron artifacts


### PR DESCRIPTION
## Summary

Second fix from the `v0.3.130` tag run (after #24):

- `ubuntu-latest`: OOM-killed (`cc1plus` SIGKILL) at 99% of the llama.cpp/wemux_moss build — `cmake --build --parallel` used all 4 cores on a 7GB runner
- `macos-14`: universal (arm64+x64) build sat on the same step for 30+ minutes with high memory pressure

Cap via `CMAKE_BUILD_PARALLEL_LEVEL=2` (respected by `cmake --build --parallel`), trading a few minutes of build time for reliable three-platform builds.

## Changes

- [x] CI / build pipeline change

## Testing

- [x] workflow YAML valid
- [ ] next `v0.3.130` tag run

## AI-generated code disclosure

- [x] This PR contains AI-generated or AI-assisted code
- [x] I am the human sponsor of this PR: I have reviewed every line, I can defend it in review, and I sign the DCO for it