### PR TITLE
fix(web): adapt unlinkAccount to better-auth 1.7 API

### DIFF
--- a/apps/web/src/components/settings/account-security-panel.tsx
+++ b/apps/web/src/components/settings/account-security-panel.tsx
@@ -124,7 +124,16 @@ export function AccountSecurityPanel({
       return
     }
     await run(async () => {
-      await betterAuthClient.unlinkAccount({ providerId: 'google' })
+      // better-auth >= 1.7：unlinkAccount 只接受行级 accountId，需先拉取账号列表定位 google 绑定
+      const { data: accounts, error } = await betterAuthClient.listAccounts()
+      if (error || !accounts) {
+        throw new Error(error?.message ?? tr('获取账号列表失败', 'Failed to load linked accounts'))
+      }
+      const google = accounts.find((account) => account.providerId === 'google')
+      if (!google) {
+        throw new Error(tr('未找到 Google 账号绑定', 'Google account is not linked'))
+      }
+      await betterAuthClient.unlinkAccount({ accountId: google.accountId })
     })
   }
 


### PR DESCRIPTION
## Summary

Repairs the typecheck broken on `main` by the grouped dependency update #22 (`better-auth` 1.6.7 → 1.7.2):

```
error TS2353: 'providerId' does not exist in type 'Prettify<{ accountId: string; } & { fetchOptions?… }>'
```

better-auth ≥ 1.7 `unlinkAccount` accepts a row-level `accountId` only. Fetch the linked-account list first, locate the `google` binding, then unlink by `accountId`.

## Related issue

Unblocks CI on main (red since #22 merged) and the pending v0.3.130 desktop release.

## Changes

- [x] Bug fix

## Testing

- [x] `tsc --noEmit -p tsconfig.json` passes locally against the 1.7.2 lockfile
- [ ] CI on this PR

## AI-generated code disclosure

- [x] This PR contains AI-generated or AI-assisted code
- [x] I am the human sponsor of this PR: I have reviewed every line, I can defend it in review, and I sign the DCO for it