### PR TITLE
fix(desktop): set safe executableName for AppImage packaging

### DIFF
--- a/apps/desktop/electron-builder.config.cjs
+++ b/apps/desktop/electron-builder.config.cjs
@@ -16,6 +16,9 @@ const shouldSignMac = Boolean(process.env.CSC_LINK || process.env.MACOS_CERTIFIC
 module.exports = {
   appId: 'com.wemux.app',
   productName: 'Wemux',
+  // 包名是 scoped（@wemux/desktop），electron-builder 会拿它当可执行文件名，
+  // '@' 和 '/' 在 AppImage 路径里不合法 —— 显式指定安全名称。
+  executableName: 'wemux-desktop',
   extraMetadata: {
     version: productPackage.version,
     description: 'Wemux desktop client',


### PR DESCRIPTION
## Summary

Fourth fix from the `v0.3.130` release run series. Linux packaging failed at the very last step:

```
⨯ failed to build AppImage error=executableName contains characters that cannot
be safely used in file paths: @wemuxdesktop
```

electron-builder derives the executable name from the scoped package name (`@wemux/desktop`), and `@`/`/` are rejected in AppImage paths. Pin `executableName: 'wemux-desktop'` explicitly.

## Changes

- [x] Bug fix

## Testing

- [x] `electron-builder.config.cjs` parses with the new field
- [ ] next tag run: AppImage builds

## AI-generated code disclosure

- [x] This PR contains AI-generated or AI-assisted code
- [x] I am the human sponsor of this PR: I have reviewed every line, I can defend it in review, and I sign the DCO for it