### PR TITLE
feat(desktop): build-time server lock for commercial distributions

### DIFF
--- a/apps/web/src/lib/runtime-config.ts
+++ b/apps/web/src/lib/runtime-config.ts
@@ -9,6 +9,7 @@ type RuntimeEnv = ImportMeta['env'] & {
   VITE_DEMO_EMAIL?: string
   VITE_COMMUNITY_DISCORD_URL?: string
   VITE_COMMUNITY_WECHAT_QR_URL?: string
+  VITE_DESKTOP_SERVER_LOCKED?: string
 }
 
 const trimTrailingSlash = (value: string) => value.replace(/\/$/, '')
@@ -190,8 +191,12 @@ export const isManagedCloudDevOnlyEnabled = () => isDevEnvironment() || isPrevie
 export const DEFAULT_SERVER_URL = 'https://wemux.ai'
 const CUSTOM_SERVER_STORAGE_KEY = 'wemux.serverUrl'
 
-/** 读取用户自定义服务器地址（未设置返回 null） */
+/** 商业分发构建锁：置 1 时桌面客户端固定连默认官方服务，忽略/禁用自定义服务器 */
+export const isDesktopServerLocked = (): boolean => getEnvValue('VITE_DESKTOP_SERVER_LOCKED') === '1'
+
+/** 读取用户自定义服务器地址（未设置返回 null；锁定构建恒返回 null） */
 export const getCustomServerUrl = (): string | null => {
+  if (isDesktopServerLocked()) return null
   if (typeof window === 'undefined') return null
   try {
     return window.localStorage.getItem(CUSTOM_SERVER_STORAGE_KEY)
@@ -202,6 +207,7 @@ export const getCustomServerUrl = (): string | null => {
 
 /** 保存用户自定义服务器地址（校验 http/https，去尾部斜杠）；非法输入不保存 */
 export const setCustomServerUrl = (url: string): boolean => {
+  if (isDesktopServerLocked()) return false
   if (typeof window === 'undefined') return false
   const trimmed = url.trim().replace(/\/+$/, '')
   if (!/^https?:\/\//i.test(trimmed)) {

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -15,7 +15,7 @@ import { useAuth } from '../lib/auth-context'
 import { useTranslation } from '../lib/i18n/react'
 import { buildNoIndexHead } from '../lib/marketing-site'
 import { isMacNativeClient, isNativeClient } from '../lib/native-client'
-import { clearCustomServerUrl, DEFAULT_SERVER_URL, getCustomServerUrl, resolveCanonicalLoopbackUrl, setCustomServerUrl } from '../lib/runtime-config'
+import { clearCustomServerUrl, DEFAULT_SERVER_URL, getCustomServerUrl, isDesktopServerLocked, resolveCanonicalLoopbackUrl, setCustomServerUrl } from '../lib/runtime-config'
 import { cn } from '../lib/utils'
 
 export const Route = createFileRoute('/login')({
@@ -325,8 +325,8 @@ export function LoginPage() {
           <p className="text-xs leading-5 text-zinc-500">{subtitle}</p>
         </header>
 
-        {/* 桌面端客户端：服务器地址选择（自托管用户连自己的实例；浏览器网页不显示） */}
-        {isNativeClient() ? <ServerSelector tr={tr} /> : null}
+        {/* 桌面端客户端：服务器地址选择（自托管用户连自己的实例；商业锁定构建与浏览器网页不显示） */}
+        {isNativeClient() && !isDesktopServerLocked() ? <ServerSelector tr={tr} /> : null}
 
         {checkingSession ? <LoadingNotice /> : null}
         {!checkingSession ? (


### PR DESCRIPTION
## What
`VITE_DESKTOP_SERVER_LOCKED=1` build flag pins native (desktop/mobile) clients to the default official server:
- `getCustomServerUrl()` always returns null (localStorage override ignored)
- `setCustomServerUrl()` is a no-op
- the login-page server selector is hidden

## Why
Commercial (cloud-hosted) desktop builds are distributed via the R2 channel and must not expose a server-picker — the edition experience comes from the server, and the commercial channel locks it to the official service. Community builds keep full self-hosted server selection.

Flag is edition-neutral core capability; unset = behavior unchanged.