### PR TITLE
fix(desktop): expect x86_64 AppImage name in release manifest

### DIFF
--- a/scripts/desktop-release.mjs
+++ b/scripts/desktop-release.mjs
@@ -52,7 +52,7 @@ const expectedArtifacts = {
   'darwin-aarch64': `Wemux-${version}-arm64.dmg`,
   'darwin-x86_64': `Wemux-${version}-x64.dmg`,
   'windows-x86_64': `Wemux-${version}-x64-setup.exe`,
-  'linux-x86_64': `Wemux-${version}-x64.AppImage`,
+  'linux-x86_64': `Wemux-${version}-x86_64.AppImage`,
 }
 
 const sha256File = (filePath) => {


### PR DESCRIPTION
## Summary

`scripts/desktop-release.mjs` expects `Wemux-<version>-x64.AppImage`, but electron-builder's Linux `` token expands to `x86_64` — the manifest step aborted with `missing Electron artifact for linux-x86_64`. Surfaced during the v0.3.130 release build; aligns the script with actual builder output.

Kept for source builders / future reuse of the manifest tooling even though the official community desktop pipeline was retired in #41.

## Changes

- [x] Bug fix

## Testing

- [x] `node --check` passes; script ran end-to-end against the real v0.3.130 bundles with this fix

## AI-generated code disclosure

- [x] This PR contains AI-generated or AI-assisted code
- [x] I am the human sponsor of this PR: I have reviewed every line, I can defend it in review, and I sign the DCO for it