### PR TITLE
fix(server): send 301 for legacy domain redirects on GET/HEAD

### DIFF
--- a/apps/server/src/routes/http.ts
+++ b/apps/server/src/routes/http.ts
@@ -143,7 +143,10 @@ export const createHttpApp = () => {
   app.use('*', async (c, next) => {
     const redirectUrl = resolveLegacyDomainRedirect(c.req.url, c.req.header('host'))
     if (redirectUrl) {
-      return c.redirect(redirectUrl, 308)
+      // 301 是可缓存的永久重定向，搜索引擎迁移（Search Console 地址更改）只接受 301；
+      // 非 GET/HEAD 保留 308，避免 legacy API 客户端的方法被改写为 GET。
+      const method = c.req.method.toUpperCase()
+      return c.redirect(redirectUrl, method === 'GET' || method === 'HEAD' ? 301 : 308)
     }
 
     const pathRedirect = resolveLegacyPathRedirect(c.req.url)


### PR DESCRIPTION
## Summary
- Legacy domain redirects (vibemux.com → wemux.ai, vibemux.xyz → wemux.xyz) now send **301** for GET/HEAD requests and keep **308** for other methods.
- Google Search Console's Change of Address validator only accepts 301; 308 failed the「来自首页的 301 重定向」check.
- 301 is cacheable and standards-compliant for permanent moves; 308 is retained for non-GET/HEAD so legacy API clients don't get their method rewritten to GET.

## Verification
- `pnpm typecheck` ✅
- `node scripts/open-core/public-boundary.mjs --staged` ✅
- Live behavior after Cloudflare edge rule (independent): `curl -I https://vibemux.com/` → 301 → https://wemux.ai/

## Notes
- GSC Change of Address vibemux.com → wemux.ai was submitted successfully on 2026-09-03 after this behavior went live at the edge; this commit makes the origin behavior consistent (belt-and-suspenders for direct-to-origin traffic and future edge-rule removal).