### PR TITLE
feat(download): redesign download page and add desktop entry

### DIFF
--- a/apps/web/src/components/download/download-page.tsx
+++ b/apps/web/src/components/download/download-page.tsx
@@ -4,144 +4,302 @@
 // [PROTOCOL]: 变更时更新此头部，然后检查 AGENTS.md
 
 import { useEffect, useState } from 'react'
+import { Download, CheckCircle2 } from 'lucide-react'
 
-import { MarketingPageLayout, MarketingSection } from '../marketing/marketing-page-layout'
+import { MarketingPageLayout } from '../marketing/marketing-page-layout'
+import { useTranslation } from '../../lib/i18n/react'
 
-/** 下载清单公开地址（CI 发布时上传为 GitHub Release asset；失败则回退到仓库内 fallback manifest） */
-const DOWNLOAD_MANIFEST_URL =
-  import.meta.env.VITE_DESKTOP_DOWNLOAD_MANIFEST_URL || 'https://github.com/wemux-ai/wemux/releases/latest/download/downloads.json'
+/** 商业版下载清单（R2 分发） */
+const DOWNLOAD_MANIFEST_URL = 'https://downloads.wemux.ai/desktop/downloads.json'
+const DOWNLOAD_BASE_URL = 'https://downloads.wemux.ai/desktop'
 
-export type DesktopDownloadPlatform = {
-  id: string
-  os: 'macos' | 'windows' | 'linux'
-  label: string
-  recommended: boolean
-  file: string
-  url: string | null
-  sizeBytes: number | null
-  sha256: string | null
+export type R2DownloadFile = {
+  name: string
+  size: number
+  sha512: string
 }
 
-export type DesktopDownloadsManifest = {
-  schemaVersion: number
+export type R2DownloadsManifest = {
   version: string
-  publishedAt: string | null
-  notes: string
-  platforms: DesktopDownloadPlatform[]
+  generatedAt: string
+  files: R2DownloadFile[]
 }
 
-const formatSize = (bytes: number | null) => {
-  if (bytes === null || !Number.isFinite(bytes)) {
-    return null
-  }
+// Fallback manifest（构建时从 R2 拷贝的快照）
+export type DesktopDownloadsManifest = R2DownloadsManifest
+
+const formatSize = (bytes: number) => {
   if (bytes < 1024 * 1024) {
-    return `${Math.max(1, Math.round(bytes / 1024))} KB`
+    return `${Math.round(bytes / 1024)} KB`
   }
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
-function PlatformCard({ platform }: { platform: DesktopDownloadPlatform }) {
-  const size = formatSize(platform.sizeBytes)
+type PlatformInfo = {
+  id: string
+  os: 'macos' | 'windows'
+  label: string
+  labelEn: string
+  arch: string
+  recommended: boolean
+  file: R2DownloadFile
+}
+
+function detectOS(): 'macos' | 'windows' | 'other' {
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.includes('mac')) return 'macos'
+  if (ua.includes('win')) return 'windows'
+  return 'other'
+}
+
+function detectArch(): 'arm64' | 'x64' {
+  // 简单检测：M1/M2 Mac 或其他
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.includes('arm') || ua.includes('aarch64')) return 'arm64'
+  return 'x64'
+}
+
+function parsePlatforms(manifest: R2DownloadsManifest): PlatformInfo[] {
+  const platforms: PlatformInfo[] = []
+  
+  // macOS arm64
+  const macArm64Dmg = manifest.files.find(f => f.name.includes('arm64.dmg'))
+  if (macArm64Dmg) {
+    platforms.push({
+      id: 'macos-arm64',
+      os: 'macos',
+      label: 'macOS（Apple Silicon）',
+      labelEn: 'macOS (Apple Silicon)',
+      arch: 'arm64',
+      recommended: detectOS() === 'macos' && detectArch() === 'arm64',
+      file: macArm64Dmg,
+    })
+  }
+
+  // macOS x64
+  const macX64Dmg = manifest.files.find(f => f.name.includes('x64.dmg') || (f.name.includes('mac.zip') && !f.name.includes('arm64')))
+  if (macX64Dmg) {
+    platforms.push({
+      id: 'macos-x64',
+      os: 'macos',
+      label: 'macOS（Intel）',
+      labelEn: 'macOS (Intel)',
+      arch: 'x64',
+      recommended: detectOS() === 'macos' && detectArch() === 'x64',
+      file: macX64Dmg,
+    })
+  }
+
+  // Windows x64
+  const winExe = manifest.files.find(f => f.name.endsWith('.exe'))
+  if (winExe) {
+    platforms.push({
+      id: 'windows-x64',
+      os: 'windows',
+      label: 'Windows（x64）',
+      labelEn: 'Windows (x64)',
+      arch: 'x64',
+      recommended: detectOS() === 'windows',
+      file: winExe,
+    })
+  }
+
+  return platforms
+}
+
+function PlatformCard({ platform, language }: { platform: PlatformInfo; language: 'zh' | 'en' }) {
+  const downloadUrl = `${DOWNLOAD_BASE_URL}/${platform.file.name}`
+  const size = formatSize(platform.file.size)
 
   return (
-    <article className="border border-white/[0.08] bg-black/25 p-5">
-      <div className="flex items-center justify-between gap-3">
-        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-violet-300">{platform.label}</p>
-        {platform.recommended ? (
-          <span className="border border-violet-500/40 bg-violet-500/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em] text-violet-200">
-            Recommended
+    <article className="group relative overflow-hidden rounded-xl border border-white/[0.08] bg-black/40 p-6 transition hover:border-white/[0.15] hover:bg-black/60">
+      {/* 推荐标签 */}
+      {platform.recommended && (
+        <div className="absolute right-4 top-4">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-emerald-400">
+            <CheckCircle2 className="h-3 w-3" />
+            {language === 'zh' ? '推荐' : 'Recommended'}
           </span>
-        ) : null}
+        </div>
+      )}
+
+      {/* 平台信息 */}
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-white">
+          {language === 'zh' ? platform.label : platform.labelEn}
+        </h3>
+        <p className="mt-1 font-mono text-xs text-zinc-500">{platform.file.name}</p>
       </div>
-      <p className="mt-4 truncate font-mono text-[11px] text-zinc-500" title={platform.file}>
-        {platform.file}
-      </p>
-      <div className="mt-5">
-        {platform.url ? (
-          <a
-            className="inline-flex items-center gap-2 bg-violet-600 px-4 py-3 font-mono text-[10px] uppercase tracking-[0.18em] text-white transition hover:bg-violet-500"
-            href={platform.url}
-            rel="noopener noreferrer"
-          >
-            Download
-            {size ? <span className="text-violet-200">{size}</span> : null}
-          </a>
-        ) : (
-          <span className="inline-flex items-center gap-2 border border-white/[0.12] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-500">
-            Coming soon
-          </span>
-        )}
-      </div>
-      {platform.sha256 ? (
-        <p className="mt-4 break-all font-mono text-[10px] leading-5 text-zinc-600">
-          SHA-256 {platform.sha256}
+
+      {/* 下载按钮 */}
+      <a
+        href={downloadUrl}
+        className="group/btn inline-flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-3 text-sm font-semibold text-black transition hover:bg-zinc-100"
+        rel="noopener noreferrer"
+      >
+        <Download className="h-4 w-4 transition group-hover/btn:translate-y-0.5" />
+        <span>{language === 'zh' ? '下载' : 'Download'}</span>
+        <span className="text-zinc-600">{size}</span>
+      </a>
+
+      {/* SHA512 校验码（折叠显示） */}
+      <details className="mt-3">
+        <summary className="cursor-pointer text-xs text-zinc-500 hover:text-zinc-400">
+          {language === 'zh' ? '查看 SHA-512' : 'Show SHA-512'}
+        </summary>
+        <p className="mt-2 break-all rounded bg-black/60 px-2 py-1.5 font-mono text-[10px] leading-relaxed text-zinc-600">
+          {platform.file.sha512}
         </p>
-      ) : null}
+      </details>
     </article>
   )
 }
 
 export function DownloadPage({ manifest: fallbackManifest }: { manifest: DesktopDownloadsManifest }) {
-  const [manifest, setManifest] = useState<DesktopDownloadsManifest>(fallbackManifest)
+  const { language } = useTranslation()
+  const [manifest, setManifest] = useState<R2DownloadsManifest>(fallbackManifest)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let cancelled = false
+    setLoading(true)
     fetch(DOWNLOAD_MANIFEST_URL, { cache: 'no-store' })
       .then((response) => {
-        if (!response.ok) {
-          throw new Error(`downloads.json ${response.status}`)
-        }
-        return response.json() as Promise<DesktopDownloadsManifest>
+        if (!response.ok) throw new Error(`HTTP ${response.status}`)
+        return response.json() as Promise<R2DownloadsManifest>
       })
       .then((liveManifest) => {
-        if (!cancelled && liveManifest?.platforms?.length) {
+        if (!cancelled && liveManifest?.files?.length) {
           setManifest(liveManifest)
         }
       })
-      .catch(() => {
-        // 网络失败或 CORS 未配时回退到仓库内 fallback manifest，页面仍可渲染
+      .catch((err) => {
+        console.warn('Failed to fetch live manifest:', err)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
       })
     return () => {
       cancelled = true
     }
   }, [])
 
-  const macPlatforms = manifest.platforms.filter((platform) => platform.os === 'macos')
-  const otherPlatforms = manifest.platforms.filter((platform) => platform.os !== 'macos')
+  const platforms = parsePlatforms(manifest)
+  const macPlatforms = platforms.filter((p) => p.os === 'macos')
+  const winPlatforms = platforms.filter((p) => p.os === 'windows')
+
+  const detectedOS = detectOS()
+  const recommendedPlatform = platforms.find((p) => p.recommended)
 
   return (
     <MarketingPageLayout
-      description="Download the Wemux desktop client for macOS, Windows, and Linux. The desktop app keeps Agent chat, workspaces, tasks, and the local worker in one window."
-      eyebrow="Download"
-      title="Get the Wemux desktop app."
+      description={
+        language === 'zh'
+          ? '下载 Wemux 桌面客户端，支持 macOS 和 Windows。'
+          : 'Download the Wemux desktop client for macOS and Windows.'
+      }
+      eyebrow={language === 'zh' ? '下载' : 'Download'}
+      title={language === 'zh' ? '下载 Wemux 桌面端' : 'Download Wemux Desktop'}
     >
-      <MarketingSection description={`Mac 版（Apple Silicon / Intel）· 当前版本 v${manifest.version}`} title="Mac 版">
-        <div className="grid gap-4 sm:grid-cols-2">
-          {macPlatforms.map((platform) => (
-            <PlatformCard key={platform.id} platform={platform} />
-          ))}
-        </div>
-      </MarketingSection>
+      {/* Hero 区域 */}
+      <section className="mb-16">
+        <div className="rounded-2xl border border-white/[0.08] bg-gradient-to-br from-black/60 to-black/40 p-8 sm:p-12">
+          <div className="mx-auto max-w-2xl text-center">
+            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-1.5 text-sm font-medium text-emerald-400">
+              <span className="h-2 w-2 rounded-full bg-emerald-500 shadow-[0_0_12px_rgba(52,211,153,0.6)]" />
+              {language === 'zh' ? `最新版本 v${manifest.version}` : `Latest v${manifest.version}`}
+            </div>
+            
+            <h2 className="mb-4 text-2xl font-bold text-white sm:text-3xl">
+              {language === 'zh'
+                ? '原生桌面体验，锁定官方云服务'
+                : 'Native Desktop Experience, Official Cloud Only'}
+            </h2>
+            
+            <p className="mb-8 text-sm leading-relaxed text-zinc-400 sm:text-base">
+              {language === 'zh'
+                ? '商业版桌面端预配置官方云服务（wemux.ai），开箱即用。支持 macOS（Apple Silicon / Intel）与 Windows。'
+                : 'Commercial desktop app pre-configured for official cloud (wemux.ai), ready out of the box. Supports macOS (Apple Silicon / Intel) and Windows.'}
+            </p>
 
-      <MarketingSection description="Windows 和 Linux 版本即将推出" title="其他平台">
-        <div className="grid gap-4 sm:grid-cols-2">
-          {otherPlatforms.map((platform) => (
-            <PlatformCard key={platform.id} platform={platform} />
-          ))}
+            {/* 快速下载按钮 */}
+            {recommendedPlatform && (
+              <a
+                href={`${DOWNLOAD_BASE_URL}/${recommendedPlatform.file.name}`}
+                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition hover:bg-zinc-100"
+              >
+                <Download className="h-4 w-4" />
+                <span>
+                  {language === 'zh'
+                    ? `下载 ${recommendedPlatform.label}`
+                    : `Download for ${recommendedPlatform.labelEn}`}
+                </span>
+                <span className="text-zinc-600">{formatSize(recommendedPlatform.file.size)}</span>
+              </a>
+            )}
+          </div>
         </div>
-      </MarketingSection>
+      </section>
 
-      <MarketingSection description="Release notes for the current desktop build." title="What's new">
-        <p className="text-sm leading-7 text-zinc-300">{manifest.notes}</p>
-        <div className="mt-5 flex flex-wrap gap-3 font-mono text-[10px] uppercase tracking-[0.18em]">
-          <a
-            className="border border-white/[0.12] px-4 py-3 text-zinc-300 transition hover:border-white/30 hover:text-white"
-            href="/changelog"
-          >
-            Full changelog
-          </a>
-        </div>
-      </MarketingSection>
+      {/* macOS 下载区 */}
+      {macPlatforms.length > 0 && (
+        <section className="mb-12">
+          <div className="mb-6">
+            <h2 className="text-xl font-bold text-white">macOS</h2>
+            <p className="mt-1 text-sm text-zinc-500">
+              {language === 'zh'
+                ? '支持 Apple Silicon（M1/M2/M3）与 Intel 芯片'
+                : 'Supports Apple Silicon (M1/M2/M3) and Intel chips'}
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {macPlatforms.map((platform) => (
+              <PlatformCard key={platform.id} language={language} platform={platform} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Windows 下载区 */}
+      {winPlatforms.length > 0 && (
+        <section className="mb-12">
+          <div className="mb-6">
+            <h2 className="text-xl font-bold text-white">Windows</h2>
+            <p className="mt-1 text-sm text-zinc-500">
+              {language === 'zh' ? '支持 Windows 10/11（x64）' : 'Supports Windows 10/11 (x64)'}
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {winPlatforms.map((platform) => (
+              <PlatformCard key={platform.id} language={language} platform={platform} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* 说明区 */}
+      <section className="rounded-xl border border-white/[0.08] bg-black/20 p-6">
+        <h3 className="mb-3 text-sm font-semibold text-white">
+          {language === 'zh' ? '📦 商业版说明' : '📦 Commercial Edition Notes'}
+        </h3>
+        <ul className="space-y-2 text-sm leading-relaxed text-zinc-400">
+          <li>
+            {language === 'zh'
+              ? '• 桌面端已锁定官方云服务（wemux.ai），无法切换其他服务器'
+              : '• Desktop app is locked to official cloud (wemux.ai), cannot switch servers'}
+          </li>
+          <li>
+            {language === 'zh'
+              ? '• 自托管用户请使用 Web 界面或从开源仓库源码自行构建'
+              : '• Self-hosted users: use Web UI or build from open-source repository'}
+          </li>
+          <li>
+            {language === 'zh'
+              ? '• macOS 需要 macOS 11 或更高版本；Windows 需要 Windows 10 或更高版本'
+              : '• macOS requires macOS 11+; Windows requires Windows 10+'}
+          </li>
+        </ul>
+      </section>
     </MarketingPageLayout>
   )
 }

--- a/apps/web/src/components/user-menu-popover.tsx
+++ b/apps/web/src/components/user-menu-popover.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { ChevronRight, LogOut, Settings, User as UserIcon, HelpCircle, FileText, Home } from 'lucide-react'
+import { ChevronRight, LogOut, Settings, User as UserIcon, HelpCircle, FileText, Home, Download } from 'lucide-react'
 import { useNavigate } from '@tanstack/react-router'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
@@ -117,6 +117,11 @@ export function UserMenuPopover({ user, onLogout, language = 'zh' }: UserMenuPop
 
           {/* 外部链接 */}
           <div className="space-y-0.5">
+            <MenuLinkItem
+              icon={Download}
+              label={language === 'zh' ? '下载桌面端' : 'Download Desktop'}
+              onClick={() => handleNavigate('/download')}
+            />
             <MenuLinkItem
               icon={Home}
               label={language === 'zh' ? '主页' : 'Home'}

--- a/apps/web/src/data/desktop-downloads.json
+++ b/apps/web/src/data/desktop-downloads.json
@@ -1,48 +1,31 @@
 {
-  "schemaVersion": 1,
-  "version": "0.3.115",
-  "publishedAt": null,
-  "notes": "首版 macOS 桌面客户端（Apple Silicon）：Agent 聊天 / 工作区 / 任务一体化，支持系统托盘、深链（Wemux://）、自动更新。",
-  "platforms": [
+  "version": "0.3.131",
+  "generatedAt": "2026-09-03T21:11:20.284Z",
+  "files": [
     {
-      "id": "darwin-aarch64",
-      "os": "macos",
-      "label": "macOS (Apple Silicon)",
-      "recommended": true,
-      "file": "wemux_0.3.115_aarch64.dmg",
-      "url": null,
-      "sizeBytes": null,
-      "sha256": null
+      "name": "Wemux-0.3.131-arm64-mac.zip",
+      "size": 163675226,
+      "sha512": "YhBbJ4jJJPBKG64Cd7H0vrwm8+Ix//c6tT8DBg5OcJxHWH/sF8ueq0wmpvLuhTQGVqSBSTfcHZrfnXGNSXuy8Q=="
     },
     {
-      "id": "darwin-x86_64",
-      "os": "macos",
-      "label": "macOS (Intel)",
-      "recommended": false,
-      "file": "wemux_0.3.127_x64.dmg",
-      "url": null,
-      "sizeBytes": null,
-      "sha256": null
+      "name": "Wemux-0.3.131-arm64.dmg",
+      "size": 163940050,
+      "sha512": "m4E2EdXs4rGW+1N8jsCrseEQZLJkgiWq+9qTyWmqpOJ1ShRy3DitxlKLnS/woGU1VAy2q3E262qRY6IaMqskew=="
     },
     {
-      "id": "windows-x86_64",
-      "os": "windows",
-      "label": "Windows (x64)",
-      "recommended": false,
-      "file": "wemux_0.3.115_x64-setup.exe",
-      "url": null,
-      "sizeBytes": null,
-      "sha256": null
+      "name": "Wemux-0.3.131-mac.zip",
+      "size": 167599983,
+      "sha512": "umcECJ3NfYjsHnmUokGPAP0yzIKbOynxUNf+xFY19yUSDUt6unYWO7qv0Hr86YcMkOrPlxTwbC1ZCjFNZHOIxA=="
     },
     {
-      "id": "linux-x86_64",
-      "os": "linux",
-      "label": "Linux (AppImage)",
-      "recommended": false,
-      "file": "wemux_0.3.115_amd64.AppImage",
-      "url": null,
-      "sizeBytes": null,
-      "sha256": null
+      "name": "Wemux-0.3.131-x64-setup.exe",
+      "size": 143219386,
+      "sha512": "tYF4F0Y1hdEjuYS+MDJ0jPmN2u113nNPAqSI8d6rwB2JT1/4qQZnpnUwJ3iQCHPd4O0+FSiPf9PYL8mKW9y/tA=="
+    },
+    {
+      "name": "Wemux-0.3.131-x64.dmg",
+      "size": 167835837,
+      "sha512": "30S/n9+XIflnjUor/PQfWp/o1M6BpV1mfvJaXd0kA4B1L/F0Mvc+WY6xqM0ULifIU71NXRqFlTZh0zg6Ube/Vg=="
     }
   ]
 }

--- a/apps/web/src/routes/download.tsx
+++ b/apps/web/src/routes/download.tsx
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/download')({
           '@type': 'SoftwareApplication',
           name: 'Wemux',
           applicationCategory: 'DeveloperApplication',
-          operatingSystem: 'macOS, Windows, Linux',
+          operatingSystem: 'macOS, Windows',
           url: buildPageUrl('/download'),
           image: marketingSite.ogImageUrl,
           description: seoPage.description,


### PR DESCRIPTION
## 📦 改动内容

### 任务 1：重新设计下载页面
- ✅ 采用现代深色主题，匹配落地页设计风格
- ✅ 数据源从 GitHub Releases 切换到 R2 ()
- ✅ 自动检测用户操作系统和架构，推荐对应版本
- ✅ 更新 fallback manifest 到 v0.3.131（R2 格式）
- ✅ 显示版本号、文件大小、SHA512 校验码
- ✅ Hero 区域快速下载按钮
- ✅ 双语支持（中文/英文）
- ✅ 响应式设计

### 任务 2：产品内添加下载入口
- ✅ 在用户菜单（头像下拉）添加下载桌面端入口
- ✅ 点击跳转到 /download 页面
- ✅ 双语支持

## 📊 支持平台
- macOS arm64 (Apple Silicon)
- macOS x64 (Intel)
- Windows x64

## 🔍 测试
- ✅ Typecheck 通过
- ✅ 访问 /download 显示新设计页面
- ✅ 用户菜单显示下载入口

## 📸 预览
新下载页面采用深色主题，自动检测平台并推荐，显示完整下载信息。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>