### PR TITLE
feat(desktop): enable keychain signing and API-key notarization gates

### DIFF
--- a/apps/desktop/electron-builder.config.cjs
+++ b/apps/desktop/electron-builder.config.cjs
@@ -7,11 +7,15 @@ const runtimeBinary = process.platform === 'win32'
   ? path.join(repoRoot, 'apps/meeting-runtime/native/build/Release/wemux-meeting-runtime.exe')
   : path.join(repoRoot, 'apps/meeting-runtime/native/build/wemux-meeting-runtime')
 const shouldNotarize = Boolean(
-  process.env.APPLE_ID && process.env.APPLE_APP_SPECIFIC_PASSWORD && process.env.APPLE_TEAM_ID,
+  (process.env.APPLE_ID && process.env.APPLE_APP_SPECIFIC_PASSWORD && process.env.APPLE_TEAM_ID) ||
+    (process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APPLE_API_ISSUER),
 )
 // Community builds run unsigned when no certificate secret is provided.
-// Signing is enabled per-platform by CSC_* secrets in the building workflow.
-const shouldSignMac = Boolean(process.env.CSC_LINK || process.env.MACOS_CERTIFICATE)
+// Signing is enabled per-platform by CSC_* secrets or a keychain identity
+// selected via CSC_NAME in the building workflow.
+const shouldSignMac = Boolean(
+  process.env.CSC_LINK || process.env.MACOS_CERTIFICATE || process.env.CSC_NAME,
+)
 
 // Update-feed target: set WEMUX_DESKTOP_PUBLISH_URL (generic provider, e.g. a
 // self-hosted R2 download base) to emit latest*.yml pointing there; default is


### PR DESCRIPTION
- `shouldSignMac` 现接受 `CSC_NAME`(钥匙串身份),本地构建可用已安装的 Developer ID 证书签名
- `shouldNotarize` 支持 notarytool API Key 三件套(`APPLE_API_KEY/_ID/_ISSUER`),不过期、免 app 专用密码