### PR TITLE
docs(mobile): document local self-build path

### DIFF
--- a/docs/CLIENT-ARCHITECTURE.md
+++ b/docs/CLIENT-ARCHITECTURE.md
@@ -35,3 +35,31 @@ pnpm build:mobile
 ```
 
 Desktop packages are produced by Electron Builder. Mobile native projects can be generated with `pnpm mobile:init`; production signing remains owned by the iOS/Android release credentials rather than repository source.
+
+## Mobile self-build
+
+Official mobile installers (TestFlight / App Store, Play Store, signed APK) are not published yet; they are planned once signing credentials and store accounts are in place. Until then, community users can build the mobile app locally.
+
+Prerequisites: Node.js 22, pnpm 10, Xcode 16+ (iOS), Android Studio with its SDK (Android).
+
+```bash
+pnpm install
+pnpm mobile:init        # generates the gitignored native projects: apps/mobile/ios, apps/mobile/android
+```
+
+The mobile shell loads a running Wemux server; point `EXPO_PUBLIC_WEMUX_APP_URL` at your server URL (for example `http://<LAN-IP>:15173`) when building for a physical device. Simulator/emulator defaults already target the local dev server.
+
+Android APK for direct install:
+
+```bash
+cd apps/mobile/android
+./gradlew assembleDebug           # output: app/build/outputs/apk/debug/app-debug.apk
+```
+
+The generated project signs with a debug keystore, which is fine for local testing. For a production-grade build, configure your own release keystore in `android/app/build.gradle`.
+
+iOS on device/simulator: open `apps/mobile/ios/Wemux.xcworkspace` in Xcode, select your own development team under Signing & Capabilities, then run the `Wemux` scheme.
+
+```bash
+pnpm build:mobile      # expo export: static renderer bundle into apps/mobile/dist
+```


### PR DESCRIPTION
补齐移动端发布策略和社区自构建路径，回应 issue #49：

- 当前尚未发布 TestFlight/App Store、Play Store 或签名 APK，原因是商店账号和生产签名凭证仍是外部前置条件。
- 文档明确 `pnpm mobile:init`、Android `assembleDebug`、iOS Xcode 本地构建步骤。
- 说明物理设备的 `EXPO_PUBLIC_WEMUX_APP_URL` 配置和 debug keystore 边界。

不包含任何签名材料或凭证。
